### PR TITLE
Use seconds as time unit and add test

### DIFF
--- a/python/src/stdbscan.py
+++ b/python/src/stdbscan.py
@@ -66,8 +66,8 @@ def retrieve_neighbors(index_center, df, spatial_threshold, temporal_threshold):
     center_point = df.loc[index_center]
 
     # filter by time 
-    min_time = center_point['date_time'] - timedelta(minutes=temporal_threshold)
-    max_time = center_point['date_time'] + timedelta(minutes=temporal_threshold)
+    min_time = center_point['date_time'] - timedelta(seconds=temporal_threshold)
+    max_time = center_point['date_time'] + timedelta(seconds=temporal_threshold)
     df = df[(df['date_time'] >= min_time) & (df['date_time'] <= max_time)]
 
     # filter by distance

--- a/python/src/test_st_dbscan.py
+++ b/python/src/test_st_dbscan.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+import pandas as pd
+import argparse
+from stdbscan import st_dbscan
+
+def parse_dates(x):
+    return datetime.strptime(x, '%Y-%m-%d %H:%M:%S.%f')
+
+filename = 'sample.csv'
+
+
+def test_time():
+    df = pd.read_csv(filename,sep=";",converters={'date_time': parse_dates})
+    result_t600 = st_dbscan(df, spatial_threshold=500, temporal_threshold=600, min_neighbors=5)
+
+    df = pd.read_csv(filename,sep=";",converters={'date_time': parse_dates})
+    result_t6 = st_dbscan(df, spatial_threshold=500, temporal_threshold=0.6, min_neighbors=5)
+
+    assert not result_t600.equals(result_t6)
+
+
+if __name__ == '__main__':
+    test_time()


### PR DESCRIPTION
Hi,
the units for the time parameter `temporal_threshold` are documented as seconds in `main.py` which
is not consistent with the implementation.

I have changed the code to use seconds and added a minimal unit test which fails with the original parameterization.